### PR TITLE
Fixed 6 missing dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,13 @@ build_progs: FORCE $(bins)
 .%.o: %.c
 	@echo -e "CC\t$@"
 	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	
+.config.o: include/kleaver/extcmd.h include/kleaver/config.h include/kleaver/dep.h
+.extcmd.o: include/kleaver/extcmd.h
+.main.o: include/kleaver/build.h include/kleaver/config.h include/kleaver/extcmd.h include/kleaver/env.h
+.build.o: include/kleaver/build.h include/kleaver/dep.h include/kleaver/extcmd.h include/kleaver/env.h
+.env.o: include/kleaver/env.h
+.dep.o: include/kleaver/dep.h include/kleaver/env.h include/kleaver/extcmd.h
 
 #
 # The following rule is adapted from:


### PR DESCRIPTION
Hi, I've fixed 6 dependencies missing reported.
Those issues can cause incorrect results when kleaver is incrementally built.
For example, any changes in "include/kleaver/extcmd.h" will not cause "extcmd.o" to be rebuilt, which is incorrect. "extcmd.h" should be regarded as internal header files, so it should be included with "" rather than <>.
Other missing dependencies are also detected, but they are all in the third-party directories. Hence they don't need to be fixed.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake